### PR TITLE
Add 10 second delay after agent init

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -11,6 +11,9 @@ Bearer.init_config do |config|
   config.secret_key = ENV.fetch('BEARER_SECRET_KEY')
 end
 
+puts '-- Waiting for initialization --'
+sleep(10)
+
 # Postman-echo
 puts '-- Sending API calls to Postman-Echo --'
 HTTParty.get(


### PR DESCRIPTION
Environments are created asynchronously on the back-end. We must wait for that to happen so that all built-in rules have been created and sent to the agent.

This is a temporary measure until we fix this properly.